### PR TITLE
Update AC_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-cps-api], [1.0.1], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-cps], [1.0.1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Package was renamed from opx-cps-api to opx-cps, but the AC_INIT
macro's package name parameter was not updated at the time.