### PR TITLE
Remove upstart configuration

### DIFF
--- a/debian/opx-cps.upstart
+++ b/debian/opx-cps.upstart
@@ -1,8 +1,0 @@
-description "Openswitch cps library"
-
-start on filesystem or runlevel [2345]
-stop on runlevel [!2345]
-
-respawn
-
-exec /usr/bin/opx_cps_service


### PR DESCRIPTION
We now require systemd, so there is no sense in providing an upstart
configuration file.