### PR TITLE
Correct library paths for CPS

### DIFF
--- a/scripts/init/opx-environment
+++ b/scripts/init/opx-environment
@@ -15,5 +15,6 @@
 #
 
 
-LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu
+LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib
 PYTHONPATH=/usr/lib/opx:/usr/lib/x86_64-linux-gnu/opx
+CPS_API_METADATA_PATH=/usr/lib/opx:/usr/lib/x86_64-linux-gnu


### PR DESCRIPTION
Correct  library paths for CPS if /etc/opx/opx-environment script is present in some repos.