### PR TITLE
Returning incorrect data type.

### DIFF
--- a/src/metadata/cps_dictionary.cpp
+++ b/src/metadata/cps_dictionary.cpp
@@ -250,7 +250,7 @@ bool cps_class_attr_is_embedded(const cps_api_attr_id_t *ids, size_t ids_len) {
     cps_class_map_node_details_int_t *p = nullptr;
     _key_to_map_element.find(&key,p,true);
 
-    if (p==nullptr) return nullptr;
+    if (p==nullptr) return false;
 
     return p->embedded;
 }


### PR DESCRIPTION
cps_class_attr_is_embedded() must return a boolean, not a nullptr.  This causes a compile error in some compilers.