### PR TITLE
Restore fix to return correct type from cps_class_attr_is_embedded().

### DIFF
--- a/src/metadata/cps_dictionary.cpp
+++ b/src/metadata/cps_dictionary.cpp
@@ -253,7 +253,7 @@ bool cps_class_attr_is_embedded(const cps_api_attr_id_t *ids, size_t ids_len) {
     cps_class_map_node_details_int_t *p = nullptr;
     _key_to_map_element->find(&key,p,true);
 
-    if (p==nullptr) return nullptr;
+    if (p==nullptr) return false;
 
     return p->embedded;
 }


### PR DESCRIPTION
Restore https://github.com/open-switch/opx-cps/commit/1ce548c39e4268df9829748f280023aaf2868b81.
The original change was backed out by https://github.com/open-switch/opx-cps/commit/70642c71297dc6fbea3aa4068d2470f24eb1b2fb.