### PR TITLE
Ignore systemd errors in pre- and post-install 

### DIFF
--- a/debian/opx-cps.postinst
+++ b/debian/opx-cps.postinst
@@ -9,8 +9,12 @@ if ! getent passwd  _opx_cps> /dev/null; then
     adduser --quiet --system  --force-badname --no-create-home --ingroup _opx_cps _opx_cps
 fi
 
-systemctl unmask redis-server
-systemctl start redis-server
+# Restart redis, ignoring any error
+# (Ignoring error is needed for ONIE installation, during which systemd
+#  is not running -- this will be handled in a more elegant way in the
+#  future)
+systemctl unmask redis-server || true
+systemctl start redis-server || true
 
 #DEBHELPER#
 

--- a/debian/opx-cps.preinst
+++ b/debian/opx-cps.preinst
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-systemctl stop redis-server
+# Stop redis, ignoring any error
+# (Ignoring error is needed for ONIE installation, during which systemd
+#  is not running -- this will be handled in a more elegant way in the
+#  future)
+systemctl stop redis-server || true
 
 #DEBHELPER#


### PR DESCRIPTION
(systemd not running during ONIE installation)